### PR TITLE
Load suggestions from JSON and harden DOM insertion

### DIFF
--- a/Smart search/index.html
+++ b/Smart search/index.html
@@ -19,7 +19,6 @@
       </div>
     </div>
 
-    <script src="js/suggestions.js"></script>
     <script src="js/script.js"></script>
 
   </body>

--- a/Smart search/js/script.js
+++ b/Smart search/js/script.js
@@ -1,4 +1,10 @@
 
+let suggestions = [];
+fetch('js/suggestions.json')
+  .then(response => response.json())
+  .then(data => suggestions = data)
+  .catch(err => console.error('Не удалось загрузить подсказки', err));
+
 const searchWrapper = document.querySelector(".search-input");
 const inputBox = searchWrapper.querySelector("input");
 const suggBox = searchWrapper.querySelector(".autocom-box");
@@ -17,18 +23,13 @@ inputBox.onkeyup = (e)=>{
             linkTag.click();
         }
         emptyArray = suggestions.filter((data)=>{
-            
             return data.toLocaleLowerCase().startsWith(userData.toLocaleLowerCase());
         });
-        emptyArray = emptyArray.map((data)=>{
-            
-            return data = `<li>${data}</li>`;
-        });
-        searchWrapper.classList.add("active"); 
+        searchWrapper.classList.add("active");
         showSuggestions(emptyArray);
         let allList = suggBox.querySelectorAll("li");
         for (let i = 0; i < allList.length; i++) {
-            
+
             allList[i].setAttribute("onclick", "select(this)");
         }
     }else{
@@ -37,14 +38,19 @@ inputBox.onkeyup = (e)=>{
 }
 
 function showSuggestions(list){
-    let listData;
+    suggBox.innerHTML = '';
+    const userValue = inputBox.value;
     if(!list.length){
-        userValue = inputBox.value;
-        listData = `<li>${userValue}</li>`;
+        const li = document.createElement('li');
+        li.textContent = userValue;
+        suggBox.appendChild(li);
     }else{
-      listData = list.join('');
+      list.forEach((data) => {
+        const li = document.createElement('li');
+        li.textContent = data;
+        suggBox.appendChild(li);
+      });
     }
-    suggBox.innerHTML = listData;
 }
 
 function select(element){


### PR DESCRIPTION
## Summary
- Remove leftover suggestions.js script include
- Fetch suggestions from JSON and render suggestions safely

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb58b529488321b8d9e6d5ecca8089